### PR TITLE
Bugfixes + breaking changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,39 +1,129 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: test ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - "1.9"
+          - "1.10"
         os:
           - ubuntu-latest
-          - macOS-latest
+          # - macOS-latest
         arch:
           - x64
+    permissions:
+      id-token: write # for OIDC
+      contents: read # to clone
+    env:
+      AWS_DEFAULT_REGION: us-east-1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+
       - uses: julia-actions/cache@v1
+
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::533267155197:role/AWSCRT-OIDC
+          role-session-name: awscrt-test
+          role-duration-seconds: 3600
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Run regular tests
+        uses: julia-actions/julia-runtest@v1
         env:
           ENDPOINT: ${{ secrets.ENDPOINT }}
           CERT_STRING: ${{ secrets.CERT_STRING }}
           PRI_KEY_STRING: ${{ secrets.PRI_KEY_STRING }}
+
+      - name: Run parallel tests
+        env:
+          ENDPOINT: ${{ secrets.ENDPOINT }}
+          CERT_STRING: ${{ secrets.CERT_STRING }}
+          PRI_KEY_STRING: ${{ secrets.PRI_KEY_STRING }}
+          AWSCRT_TESTS_PARALLEL: true
+        run: |
+          NTHREADS=$(($(nproc) * 2))
+          NTIMES=50
+          julia -t $NTHREADS test/run_parallel_commands.jl $NTIMES julia -t 2 --project -e 'using Pkg; Pkg.test()'
+
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
+
+      - uses: codecov/codecov-action@v4
+        with:
+          file: ./lcov.info
+          fail_ci_if_error: false
+
+  downgrade-test:
+    name: downgrade-test ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.9"
+          - "1.10"
+        os:
+          - ubuntu-latest
+          # - macOS-latest
+        arch:
+          - x64
+    permissions:
+      id-token: write # for OIDC
+      contents: read # to clone
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+
+      - uses: julia-actions/cache@v1
+
+      - uses: julia-actions/julia-downgrade-compat@v1
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::533267155197:role/AWSCRT-OIDC
+          role-session-name: awscrt-test
+          role-duration-seconds: 3600
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Run regular tests
+        uses: julia-actions/julia-runtest@v1
+        env:
+          ENDPOINT: ${{ secrets.ENDPOINT }}
+          CERT_STRING: ${{ secrets.CERT_STRING }}
+          PRI_KEY_STRING: ${{ secrets.PRI_KEY_STRING }}
+
+      - uses: julia-actions/julia-processcoverage@v1
+
+      - uses: codecov/codecov-action@v4
         with:
           file: ./lcov.info
           fail_ci_if_error: false
@@ -46,19 +136,24 @@ jobs:
       matrix:
         version:
           - "1.9"
+          - "1.10"
         os:
           - ubuntu-latest
-          - macOS-latest
+          # - macOS-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+
       - uses: julia-actions/cache@v1
+
       - uses: julia-actions/julia-buildpkg@v1
+
       - run: |
           julia --project -e 'import Pkg; Pkg.develop(path=".."); Pkg.instantiate(); Pkg.build();'
           MQTT_ENABLED=false julia --project=sysimage -e 'import Pkg; Pkg.instantiate(); Pkg.build(); include(joinpath("sysimage", "build_sysimage.jl")); build()'

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ LibAWSCRT = "df7458b6-5204-493f-a0e7-404b4eb72fac"
 [compat]
 AWSCRT_jll = "=0.1.2"
 AWS = "1.78"
-Aqua = "0.8"
+Aqua = "0.8.4"
 CEnum = "0.4"
 CountDownLatches = "2"
 Dates = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSCRT"
 uuid = "df31ea59-17a4-4ebd-9d69-4f45266dc2c7"
-version = "0.1.5"
+version = "0.2.0"
 
 [deps]
 AWSCRT_jll = "01db5350-6ea1-5d9a-9a47-8a31a394cb9c"
@@ -11,19 +11,27 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibAWSCRT = "df7458b6-5204-493f-a0e7-404b4eb72fac"
 
 [compat]
-AWSCRT_jll = "0.1"
+AWSCRT_jll = "=0.1.2"
+AWS = "1.78"
+Aqua = "0.8"
 CEnum = "0.4"
 CountDownLatches = "2"
-ForeignCallbacks = "0.1"
+Dates = "1"
+Documenter = "1"
+ForeignCallbacks = "0.1.1"
 JSON = "0.21"
-LibAWSCRT = "0.1"
+LibAWSCRT = "=0.1.0"
+Random = "1"
+Test = "1"
 julia = "1.9"
 
 [extras]
+AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Documenter", "Random", "Test"]
+test = ["AWS", "Aqua", "Dates", "Documenter", "Random", "Test"]

--- a/src/AWSCRT.jl
+++ b/src/AWSCRT.jl
@@ -14,76 +14,44 @@ using LibAWSCRT, ForeignCallbacks, CountDownLatches, CEnum, JSON
 import Base: lock, unlock
 export lock, unlock
 
-const _AWSCRT_ALLOCATOR = Ref{Union{Ptr{aws_allocator},Nothing}}(nothing)
-const _GLOBAL_REFS = Vector{Ref}()
+const _C_IDS_LOCK = ReentrantLock()
+const _C_IDS = IdDict{Any,Any}()
+
+const _C_ON_ANY_MESSAGE_IDS_LOCK = ReentrantLock()
+const _C_ON_ANY_MESSAGE_IDS = IdDict{Any,Any}()
+
+# set during __init__
 const _LIBPTR = Ref{Ptr{Cvoid}}(Ptr{Cvoid}(0))
+const _AWSCRT_ALLOCATOR = Ref{Union{Ptr{aws_allocator},Nothing}}(nothing)
 
-function __init__()
-    _LIBPTR[] = Libc.Libdl.dlopen(LibAWSCRT.libawscrt)
-
-    _AWSCRT_ALLOCATOR[] = let level = get(ENV, "AWS_CRT_MEMORY_TRACING", "")
-        if !isempty(level)
-            level = parse(Int, strip(level))
-            level = aws_mem_trace_level(level)
-            if Symbol(level) == :UnknownMember
-                error(
-                    "Invalid value for env var AWS_CRT_MEMORY_TRACING. " *
-                    "See aws_mem_trace_level docs for valid values.",
-                )
-            end
-            frames_per_stack = parse(Int, strip(get(ENV, "AWS_CRT_MEMORY_TRACING_FRAMES_PER_STACK", "0")))
-            aws_mem_tracer_new(aws_default_allocator(), C_NULL, level, frames_per_stack)
-        else
-            aws_default_allocator()
-        end
-    end
-
-    let log_level = get(ENV, "AWS_CRT_LOG_LEVEL", "")
-        if !isempty(log_level)
-            log_level = parse(Int, strip(log_level))
-            log_level = aws_log_level(log_level)
-            if Symbol(log_level) == :UnknownMember
-                error("Invalid value for env var AWS_CRT_LOG_LEVEL. See aws_log_level docs for valid values.")
-            end
-
-            log_path = get(ENV, "AWS_CRT_LOG_PATH", "")
-            if isempty(log_path)
-                error("Env var AWS_CRT_LOG_PATH must be set to the path at which to save the log file.")
-            end
-            log_path = Ref(deepcopy(log_path))
-            push!(_GLOBAL_REFS, log_path)
-
-            logger = Ref(aws_logger(C_NULL, C_NULL, C_NULL))
-            push!(_GLOBAL_REFS, logger)
-
-            logger_options =
-                Ref(aws_logger_standard_options(log_level, Base.unsafe_convert(Ptr{Cchar}, log_path[]), C_NULL))
-            push!(_GLOBAL_REFS, logger_options)
-
-            aws_logger_init_standard(logger, _AWSCRT_ALLOCATOR[], logger_options)
-            aws_logger_set(logger)
-        end
-    end
-
-    aws_mqtt_library_init(_AWSCRT_ALLOCATOR[]) # also does io and http
-
-    # TODO try cleanup using this approach https://github.com/JuliaLang/julia/pull/20124/files
-end
+# cfunctions set during __init__
+const _C_ON_CONNECTION_INTERRUPTED = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_ON_CONNECTION_RESUMED = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_ON_CONNECTION_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_ON_DISCONNECT_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_ON_SUBSCRIBE_MESSAGE = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_ON_ANY_MESSAGE = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_ON_SUBSCRIBE_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_ON_UNSUBSCRIBE_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_ON_RESUBSCRIBE_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_ON_PUBLISH_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
 
 function _release(; include_mem_tracer = isempty(get(ENV, "AWS_CRT_MEMORY_TRACING", "")))
     aws_thread_set_managed_join_timeout_ns(5e8) # 0.5 seconds
 
-    i = findfirst(x -> x isa Ref{aws_logger}, _GLOBAL_REFS)
-    if i !== nothing
-        aws_logger_clean_up(_GLOBAL_REFS[i])
-    end
+    lock(_C_IDS_LOCK) do
+        logger = findfirst(x -> x isa Ref{aws_logger}, keys(_C_IDS))
+        if logger !== nothing
+            aws_logger_clean_up(logger)
+        end
 
-    aws_mqtt_library_clean_up() # also does io and http
-    empty!(_GLOBAL_REFS)
-    if include_mem_tracer
-        aws_mem_tracer_destroy(_AWSCRT_ALLOCATOR[])
+        aws_mqtt_library_clean_up() # also does io and http
+        empty!(_C_IDS)
+        if include_mem_tracer
+            aws_mem_tracer_destroy(_AWSCRT_ALLOCATOR[])
+        end
+        return nothing
     end
-    return nothing
 end
 
 aws_err_string(code = aws_last_error()) = "AWS Error $code: " * Base.unsafe_string(aws_error_debug_str(code))
@@ -133,5 +101,92 @@ export ShadowDocumentPreUpdateCallback
 export ShadowDocumentPostUpdateCallback
 export shadow_client
 export publish_current_state
+export wait_until_synced
+
+function __init__()
+    _LIBPTR[] = Libc.Libdl.dlopen(LibAWSCRT.libawscrt)
+
+    _C_ON_CONNECTION_INTERRUPTED[] =
+        @cfunction(_c_on_connection_interrupted, Cvoid, (Ptr{aws_mqtt_client_connection}, Cint, Ptr{Cvoid}))
+    _C_ON_CONNECTION_RESUMED[] =
+        @cfunction(_c_on_connection_resumed, Cvoid, (Ptr{aws_mqtt_client_connection}, Cint, Cint, Ptr{Cvoid}))
+    _C_ON_CONNECTION_COMPLETE[] =
+        @cfunction(_c_on_connection_complete, Cvoid, (Ptr{aws_mqtt_client_connection}, Cint, Cint, Cuchar, Ptr{Cvoid}))
+    _C_ON_DISCONNECT_COMPLETE[] =
+        @cfunction(_c_on_disconnect_complete, Cvoid, (Ptr{aws_mqtt_client_connection}, Ptr{Cvoid}))
+    _C_ON_SUBSCRIBE_MESSAGE[] = @cfunction(
+        _c_on_subscribe_message,
+        Cvoid,
+        (Ptr{aws_mqtt_client_connection}, Ptr{aws_byte_cursor}, Ptr{aws_byte_cursor}, Cuchar, Cint, Cuchar, Ptr{Cvoid})
+    )
+    _C_ON_ANY_MESSAGE[] = @cfunction(
+        _c_on_any_message,
+        Cvoid,
+        (Ptr{aws_mqtt_client_connection}, Ptr{aws_byte_cursor}, Ptr{aws_byte_cursor}, Cuchar, Cint, Cuchar, Ptr{Cvoid})
+    )
+    _C_ON_SUBSCRIBE_COMPLETE[] = @cfunction(
+        _c_on_subscribe_complete,
+        Cvoid,
+        (Ptr{aws_mqtt_client_connection}, Cuint, Ptr{aws_byte_cursor}, Cint, Cint, Ptr{Cvoid})
+    )
+    _C_ON_UNSUBSCRIBE_COMPLETE[] =
+        @cfunction(_c_on_unsubscribe_complete, Cvoid, (Ptr{aws_mqtt_client_connection}, Cuint, Cint, Ptr{Cvoid}))
+    _C_ON_RESUBSCRIBE_COMPLETE[] = @cfunction(
+        _c_on_resubscribe_complete,
+        Cvoid,
+        (Ptr{aws_mqtt_client_connection}, Cuint, Ptr{aws_array_list}, Cint, Ptr{Cvoid})
+    )
+    _C_ON_PUBLISH_COMPLETE[] =
+        @cfunction(_c_on_publish_complete, Cvoid, (Ptr{aws_mqtt_client_connection}, Cuint, Cint, Ptr{Cvoid}))
+
+    _AWSCRT_ALLOCATOR[] = let level = get(ENV, "AWS_CRT_MEMORY_TRACING", "")
+        if !isempty(level)
+            level = parse(Int, strip(level))
+            level = aws_mem_trace_level(level)
+            if Symbol(level) == :UnknownMember
+                error(
+                    "Invalid value for env var AWS_CRT_MEMORY_TRACING. " *
+                    "See aws_mem_trace_level docs for valid values.",
+                )
+            end
+            frames_per_stack = parse(Int, strip(get(ENV, "AWS_CRT_MEMORY_TRACING_FRAMES_PER_STACK", "0")))
+            aws_mem_tracer_new(aws_default_allocator(), C_NULL, level, frames_per_stack)
+        else
+            aws_default_allocator()
+        end
+    end
+
+    let log_level = get(ENV, "AWS_CRT_LOG_LEVEL", "")
+        if !isempty(log_level)
+            log_level = parse(Int, strip(log_level))
+            log_level = aws_log_level(log_level)
+            if Symbol(log_level) == :UnknownMember
+                error("Invalid value for env var AWS_CRT_LOG_LEVEL. See aws_log_level docs for valid values.")
+            end
+
+            log_path = get(ENV, "AWS_CRT_LOG_PATH", "")
+            if isempty(log_path)
+                error("Env var AWS_CRT_LOG_PATH must be set to the path at which to save the log file.")
+            end
+            log_path = Ref(deepcopy(log_path))
+            logger = Ref(aws_logger(C_NULL, C_NULL, C_NULL))
+            logger_options =
+                Ref(aws_logger_standard_options(log_level, Base.unsafe_convert(Ptr{Cchar}, log_path[]), C_NULL))
+
+            lock(_C_IDS_LOCK) do
+                _C_IDS[log_path] = nothing
+                _C_IDS[logger] = nothing
+                _C_IDS[logger_options] = nothing
+            end
+
+            aws_logger_init_standard(logger, _AWSCRT_ALLOCATOR[], logger_options)
+            aws_logger_set(logger)
+        end
+    end
+
+    aws_mqtt_library_init(_AWSCRT_ALLOCATOR[]) # also does io and http
+
+    # TODO try cleanup using this approach https://github.com/JuliaLang/julia/pull/20124/files
+end
 
 end

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+gdbargs
+log*

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -1,0 +1,293 @@
+using TestEnv
+TestEnv.activate()
+
+using Test, AWSCRT, LibAWSCRT, JSON, CountDownLatches, Random, Documenter, Aqua, Dates
+parallel = true
+
+include("util.jl")
+
+#####################################################################################################
+
+Base.errormonitor(Threads.@spawn begin
+    while true
+        GC.gc(true)
+        sleep(1)
+    end
+end)
+
+include("shadow_framework_integ_test.jl")
+
+#####################################################################################################
+
+# topic1 = "test-topic-$(Random.randstring(6))"
+# payload1 = Random.randstring(48)
+# payload2 = Random.randstring(48)
+# client_id1 = random_client_id()
+# @show topic1 payload1 client_id1
+
+# client = MQTTClient(new_tls_ctx())
+# connection = MQTTConnection(client)
+
+# any_msg = Channel(1)
+# sub_msg = Channel(1)
+
+# # on_message(
+# #     connection,
+# #     (topic::String, payload::String, dup::Bool, qos::aws_mqtt_qos, retain::Bool) -> begin
+# #         put!(any_msg, (; topic, payload, qos, retain))
+# #     end,
+# # )
+
+# task = connect(
+#     connection,
+#     ENV["ENDPOINT"],
+#     8883,
+#     client_id1;
+#     will = Will(topic1, AWS_MQTT_QOS_AT_LEAST_ONCE, "The client has gone offline!", false),
+#     on_connection_interrupted = (conn, error_code) -> begin
+#         @warn "connection interrupted" error_code
+#     end,
+#     on_connection_resumed = (conn, return_code, session_present) -> begin
+#         @info "connection resumed" return_code session_present
+#     end,
+# )
+# @test fetch(task) == Dict(:session_present => false)
+
+# task, id = subscribe(
+#     connection,
+#     topic1,
+#     AWS_MQTT_QOS_AT_LEAST_ONCE,
+#     (topic::String, payload::String, dup::Bool, qos::aws_mqtt_qos, retain::Bool) -> begin
+#         @info "subscribe callback" topic payload dup qos retain
+#     end,
+# )
+# d = fetch(task)
+
+# task, id = publish(connection, topic1, payload1, AWS_MQTT_QOS_AT_LEAST_ONCE)
+# task, id = publish(connection, topic1, payload1, AWS_MQTT_QOS_AT_LEAST_ONCE)
+
+# sleep(12)
+
+# # Subscribe, publish a message, and test we get it on both callbacks
+# task, id = subscribe(
+#     connection,
+#     topic1,
+#     AWS_MQTT_QOS_AT_LEAST_ONCE,
+#     (topic::String, payload::String, dup::Bool, qos::aws_mqtt_qos, retain::Bool) -> begin
+#         put!(sub_msg, (; topic, payload, qos, retain))
+#     end,
+# )
+# d = fetch(task)
+# @test d[:packet_id] == id
+# @test d[:topic] == topic1
+# @test d[:qos] == AWS_MQTT_QOS_AT_LEAST_ONCE
+
+# task, id = resubscribe_existing_topics(connection)
+# d = fetch(task)
+# @test d[:packet_id] == id
+# @test d[:topics] == [(topic1, AWS_MQTT_QOS_AT_LEAST_ONCE)]
+
+# for _ = 1:10
+#     payload = Random.randstring(48)
+#     @show payload
+#     task, id = publish(connection, topic1, payload, AWS_MQTT_QOS_AT_LEAST_ONCE)
+#     @test fetch(task) == Dict(:packet_id => id)
+
+#     msg = take!(sub_msg)
+#     @show msg
+#     @test msg.topic == topic1
+#     @test msg.payload == payload
+#     @test msg.qos == AWS_MQTT_QOS_AT_LEAST_ONCE
+#     @test !msg.retain
+
+#     msg = take!(any_msg)
+#     @show msg
+#     @test msg.topic == topic1
+#     @test msg.payload == payload
+#     @test msg.qos == AWS_MQTT_QOS_AT_LEAST_ONCE
+#     @test !msg.retain
+# end
+
+# @show task, id = publish(
+#     connection,
+#     "\$aws/things/AWSCRT_Test1/shadow/name/shadow-abc123/update",
+#     json(Dict("state" => Dict("desired" => Dict("foo" => 2)))),
+#     AWS_MQTT_QOS_AT_LEAST_ONCE,
+# )
+# @show fetch(task)
+
+# shadow_name = Random.randstring(6)
+# @show task, id = subscribe(
+#     connection,
+#     "\$aws/things/AWSCRT_Test1/shadow/name/shadow-$shadow_name/get/rejected",
+#     AWS_MQTT_QOS_AT_LEAST_ONCE,
+#     (topic::String, payload::String, dup::Bool, qos::aws_mqtt_qos, retain::Bool) -> begin
+#         @info "get rejected callback" topic payload dup qos retain
+
+#         task, id = publish(
+#             connection,
+#             "\$aws/things/AWSCRT_Test1/shadow/name/shadow-$shadow_name/update",
+#             json(Dict("state" => Dict("desired" => Dict("foo" => 2)))),
+#             AWS_MQTT_QOS_AT_LEAST_ONCE,
+#         )
+#         @info "get rejected callback" task id fetch(task)
+#     end,
+# )
+# @show d = fetch(task)
+
+# @show task, id = publish(
+#     connection,
+#     "\$aws/things/AWSCRT_Test1/shadow/name/shadow-$shadow_name/get",
+#     json(Dict()),
+#     AWS_MQTT_QOS_AT_LEAST_ONCE,
+# )
+# @show fetch(task)
+
+# sleep(3)
+
+"""
+summary
+
+with FCBs:
+1. publish from julia thread
+2. subscribe callback runs on CRT event loop thread, puts msg in FCBs queue, and returns
+3. julia thread waiting on FCBs queue is woken, publishes another msg, and waits again (i.e. fetch())
+4. CRT event loop thread is not blocked
+
+without FCBs:
+1. publish from julia thread
+2. subscribe callback runs on CRT event loop thread, publishes another msg, and waits (i.e. fetch())
+3. CRT event loop thread is now deadlocked waiting for the subscribe callback to run again, but the event loop is blocked due to that wait
+
+solution: ???
+need to get off the CRT event loop thread somehow to unblock the event loop
+am i just arriving back at FCBs?
+Valentin said FCBs were not necessary as of v1.9, and strictly speaking they aren't because the code "works" but we have this deadlock now
+I think it will be too much burden on the user to always have fast nonblocking callbacks and we need to keep the code running on the event loop 100% inside this package, therefore we need a solution like FCBs
+
+add comments to CRT callbacks that note they block the event loop
+"""
+
+#####################################################################################################
+
+# struct OOBShadowClient
+#     shadow_client::ShadowClient
+#     msgs::Vector{Any}
+#     shadow_callback::Function
+
+#     function OOBShadowClient(oob_connection, THING1_NAME, shadow_name)
+#         msgs = Any[]
+#         function shadow_callback(
+#             shadow_client::ShadowClient,
+#             topic::String,
+#             payload::String,
+#             dup::Bool,
+#             qos::aws_mqtt_qos,
+#             retain::Bool,
+#         )
+#             push!(msgs, (; shadow_client, topic, payload, dup, qos, retain))
+#         end
+#         return new(ShadowClient(oob_connection, THING1_NAME, shadow_name), msgs, shadow_callback)
+#     end
+# end
+
+# function subscribe_for_single_shadow_msg(oobsc, topic, payload)
+#     tasks_and_ids = subscribe(oobsc.shadow_client, AWS_MQTT_QOS_AT_LEAST_ONCE, oobsc.shadow_callback)
+#     for (task, id) in tasks_and_ids
+#         fetch(task)
+#     end
+#     fetch(publish(oobsc.shadow_client, topic, payload, AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
+#     wait_for(() -> !isempty(oobsc.msgs))
+#     fetch(unsubscribe(oobsc.shadow_client)[1])
+# end
+
+# function test_get_accepted_payload_equals_shadow_doc(payload, doc)
+#     @info "test_get_accepted_payload_equals_shadow_doc" payload doc
+#     p = JSON.parse(payload)
+#     for k in keys(doc)
+#         if k != "version"
+#             @test p["state"]["reported"][k] == doc[k]
+#         end
+#     end
+#     @test p["version"] == doc["version"]
+# end
+
+# function maybe_get(d, keys...)
+#     return if length(keys) == 1
+#         get(d, keys[1], nothing)
+#     else
+#         if haskey(d, keys[1])
+#             maybe_get(d[keys[1]], keys[2:end]...)
+#         else
+#             nothing
+#         end
+#     end
+# end
+
+# mutable struct ShadowDocMissingProperty
+#     foo::Int
+#     version::Int
+# end
+
+# connection = new_mqtt_connection()
+# shadow_name = random_shadow_name()
+# doc = Dict("foo" => 1)
+
+# values_foo = []
+# foo_cb = x -> push!(values_foo, x)
+
+# values_pre_update = []
+# pre_update_cb = x -> push!(values_pre_update, x)
+
+# values_post_update = []
+# latch_post_update = Ref(CountDownLatch(1))
+# post_update_cb = x -> begin
+#     push!(values_post_update, x)
+#     count_down(latch_post_update[])
+# end
+
+# sf = ShadowFramework(
+#     connection,
+#     THING1_NAME,
+#     shadow_name,
+#     doc;
+#     shadow_document_pre_update_callback = pre_update_cb,
+#     shadow_document_post_update_callback = post_update_cb,
+#     shadow_document_property_callbacks = Dict{String,Function}("foo" => foo_cb),
+# )
+# sc = shadow_client(sf)
+
+# msgs = []
+# function shadow_callback(
+#     shadow_client::ShadowClient,
+#     topic::String,
+#     payload::String,
+#     dup::Bool,
+#     qos::aws_mqtt_qos,
+#     retain::Bool,
+# )
+#     push!(msgs, (; shadow_client, topic, payload, dup, qos, retain))
+# end
+
+# oobc = new_mqtt_connection()
+# oobsc = OOBShadowClient(oobc, THING1_NAME, shadow_name)
+
+# fetch(subscribe(sf)[1])
+# sleep(3)
+
+# @info "publishing first update"
+# @show publish(
+#     oobsc.shadow_client,
+#     "/update",
+#     json(Dict("state" => Dict("desired" => Dict("foo" => 2)))),
+#     AWS_MQTT_QOS_AT_LEAST_ONCE,
+# )
+# sleep(3)
+# # wait_for(() -> !isempty(values_post_update))
+# # @test doc["foo"] == 2
+
+# # @info "unsubscribing"
+# # for (task, id) in unsubscribe(sf)
+# #     fetch(task)
+# # end
+# # @info "done unsubscribing"

--- a/test/debug_preserve.jl
+++ b/test/debug_preserve.jl
@@ -1,0 +1,27 @@
+mutable struct Obj
+    x::Float32
+end
+
+l = ReentrantLock()
+refs = Base.IdDict()
+
+function foo()
+    x = Obj(1234567.0f32)
+    p = Base.pointer_from_objref(x)
+    lock(l) do
+        @time refs[x] = nothing
+        @time refs[p] = nothing
+    end
+    @show refs
+    return p
+end
+
+function bar(p)
+    GC.gc(true)
+    @time haskey(refs, p)
+    x = Base.unsafe_pointer_to_objref(p)::Obj
+    @time haskey(refs, x)
+    @show x
+end
+
+bar(foo())

--- a/test/debug_preserve_task.jl
+++ b/test/debug_preserve_task.jl
@@ -1,0 +1,20 @@
+mutable struct Obj
+    x::Float32
+end
+
+function foo()
+    x = Ref(Obj(1234567.0f32))
+    p = Base.pointer_from_objref(x)
+    Threads.@spawn begin
+        GC.gc(true)
+        GC.@preserve x begin
+            GC.gc(true)
+            y = Base.unsafe_pointer_to_objref(p)::Ref{Obj}
+            @show y
+        end
+    end
+end
+
+t = foo()
+GC.gc(true)
+wait(t)

--- a/test/mqtt_test.jl
+++ b/test/mqtt_test.jl
@@ -127,6 +127,66 @@
     @test fetch(task) === nothing
 end
 
+@testset "two long subscribe callbacks don't block each other" begin
+    topic1 = "test-topic-$(Random.randstring(6))"
+    payload1 = Random.randstring(48)
+    payload2 = Random.randstring(48)
+    client_id1 = random_client_id()
+    @show topic1 payload1 client_id1
+
+    client = MQTTClient(new_tls_ctx())
+    connection = MQTTConnection(client)
+
+    task = connect(
+        connection,
+        ENV["ENDPOINT"],
+        8883,
+        client_id1;
+        will = Will(topic1, AWS_MQTT_QOS_AT_LEAST_ONCE, "The client has gone offline!", false),
+        on_connection_interrupted = (conn, error_code) -> begin
+            @warn "connection interrupted" error_code
+        end,
+        on_connection_resumed = (conn, return_code, session_present) -> begin
+            @info "connection resumed" return_code session_present
+        end,
+    )
+    @test fetch(task) == Dict(:session_present => false)
+
+    latch = CountDownLatch(2)
+    l = ReentrantLock()
+    msgs = []
+    task, id = subscribe(
+        connection,
+        topic1,
+        AWS_MQTT_QOS_AT_LEAST_ONCE,
+        (topic::String, payload::String, dup::Bool, qos::aws_mqtt_qos, retain::Bool) -> begin
+            sleep(5) # pretend we do something that takes a while
+            count_down(latch)
+            lock(l) do
+                push!(msgs, (; topic, payload, dup, qos, retain))
+            end
+        end,
+    )
+    fetch(task)
+
+    publish(connection, topic1, payload1, AWS_MQTT_QOS_AT_LEAST_ONCE)
+    publish(connection, topic1, payload2, AWS_MQTT_QOS_AT_LEAST_ONCE)
+
+    time_before = now()
+    await(latch)
+    dt = now() - time_before
+    @test dt < Second(9) # if both subscribe calls run concurrently, we should do this in less than the time it takes to run both sequentially
+    @test length(msgs) == 2
+    @test in(
+        (; topic = topic1, payload = payload1, dup = false, qos = AWS_MQTT_QOS_AT_LEAST_ONCE, retain = false),
+        msgs,
+    )
+    @test in(
+        (; topic = topic1, payload = payload2, dup = false, qos = AWS_MQTT_QOS_AT_LEAST_ONCE, retain = false),
+        msgs,
+    )
+end
+
 @testset "connect using CA string instead of a CA filepath" begin
     client_id1 = random_client_id()
 
@@ -144,4 +204,84 @@ end
 
     task = disconnect(connection)
     @test fetch(task) === nothing
+end
+
+@testset "check for memory leaks while publishing" begin
+    if parallel
+        return
+    end
+
+    topic1 = "test-topic-$(Random.randstring(6))"
+    payload1 = Random.randstring(48)
+    client_id1 = random_client_id()
+    @show topic1 payload1 client_id1
+
+    client = MQTTClient(new_tls_ctx())
+    connection = MQTTConnection(client)
+
+    any_msg = Channel(1)
+    sub_msg = Channel(1)
+
+    on_message(
+        connection,
+        (topic::String, payload::String, dup::Bool, qos::aws_mqtt_qos, retain::Bool) -> begin
+            put!(any_msg, (; topic, payload, qos, retain))
+        end,
+    )
+
+    fetch(
+        connect(
+            connection,
+            ENV["ENDPOINT"],
+            8883,
+            client_id1;
+            will = Will(topic1, AWS_MQTT_QOS_AT_LEAST_ONCE, "The client has gone offline!", false),
+            on_connection_interrupted = (conn, error_code) -> begin
+                @warn "connection interrupted" error_code
+            end,
+            on_connection_resumed = (conn, return_code, session_present) -> begin
+                @info "connection resumed" return_code session_present
+            end,
+        ),
+    )
+
+    fetch(
+        subscribe(
+            connection,
+            topic1,
+            AWS_MQTT_QOS_AT_LEAST_ONCE,
+            (topic::String, payload::String, dup::Bool, qos::aws_mqtt_qos, retain::Bool) -> begin
+                put!(sub_msg, (; topic, payload, qos, retain))
+            end,
+        )[1],
+    )
+
+    GC.gc(true)
+    start_bytes = Base.gc_live_bytes()
+    start_nids = length(AWSCRT._C_IDS)
+    for _ = 1:1000
+        task, id = publish(connection, topic1, payload1, AWS_MQTT_QOS_AT_LEAST_ONCE)
+        @test fetch(task) == Dict(:packet_id => id)
+
+        msg = take!(sub_msg)
+        @test msg.topic == topic1
+        @test msg.payload == payload1
+        @test msg.qos == AWS_MQTT_QOS_AT_LEAST_ONCE
+        @test !msg.retain
+
+        msg = take!(any_msg)
+        @test msg.topic == topic1
+        @test msg.payload == payload1
+        @test msg.qos == AWS_MQTT_QOS_AT_LEAST_ONCE
+        @test !msg.retain
+    end
+    GC.gc(true)
+
+    end_bytes = Base.gc_live_bytes()
+    end_nids = length(AWSCRT._C_IDS)
+    @show start_bytes end_bytes start_nids end_nids
+    @test end_bytes ≈ start_bytes rtol = 0.01
+    @test start_nids == end_nids
+
+    fetch(unsubscribe(connection, topic1)[1])
 end

--- a/test/run_parallel_commands.jl
+++ b/test/run_parallel_commands.jl
@@ -1,0 +1,52 @@
+function main()
+    nmaxruns = tryparse(Int, ARGS[1])
+    cmd = nmaxruns === nothing ? Cmd(ARGS) : Cmd(ARGS[begin+1:end])
+    if nmaxruns === nothing
+        @info "Running cmd on $(Threads.nthreads()) threads until stopped: $cmd"
+    else
+        @info "Running cmd on $(Threads.nthreads()) threads up to $nmaxruns times: $cmd"
+    end
+
+    print_lock = ReentrantLock()
+    nruns = Threads.Atomic{Int}(0)
+    tasks = Task[]
+    for _ = 1:Threads.nthreads()
+        t = Threads.@spawn begin
+            while true
+                stdout = IOBuffer()
+                stderr = IOBuffer()
+                try
+                    run(pipeline(cmd; stdout, stderr))
+                    old_nruns = Threads.atomic_add!(nruns, 1) + 1
+                    if nmaxruns !== nothing && old_nruns >= nmaxruns
+                        lock(print_lock) do
+                            @info "Done after $nmaxruns runs"
+                        end
+                        exit(0)
+                    end
+                    if old_nruns % 10 == 0
+                        lock(print_lock) do
+                            @info "$old_nruns successful runs so far..."
+                        end
+                    end
+                catch ex
+                    lock(print_lock) do
+                        @error "Command failed after $(nruns[]) runs." exception = ex
+                        @error "Command stdout:"
+                        println(String(take!(stdout)))
+                        @error "Command stderr:"
+                        println(String(take!(stderr)))
+                        exit(1)
+                    end
+                end
+            end
+        end
+        Base.errormonitor(t)
+        push!(tasks, t)
+    end
+    for t in tasks
+        fetch(t)
+    end
+end
+
+main()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,20 +1,27 @@
-rm(joinpath(@__DIR__, "log.txt"); force = true)
+include("testheader.jl")
 
-ENV["AWS_CRT_MEMORY_TRACING"] = "1"
-ENV["AWS_CRT_LOG_LEVEL"] = "6"
-ENV["AWS_CRT_LOG_PATH"] = joinpath(@__DIR__, "log.txt")
-ENV["JULIA_DEBUG"] = "AWSCRT"
-
-using Test, AWSCRT, LibAWSCRT, JSON, CountDownLatches, Random, Documenter, Aqua
-
-include("util.jl")
+# Inject some chaos into the tests to help expose memory bugs
+Base.errormonitor(Threads.@spawn begin
+    while true
+        GC.gc(true)
+        try
+            sleep(1)
+        catch ex
+            if !(ex isa EOFError)
+                rethrow()
+            end
+        end
+    end
+end)
 
 @testset "AWSCRT" begin
-    doctest(AWSCRT)
-    @testset "Aqua" begin
-        # TODO: see how this issue resolves and update https://github.com/JuliaTesting/Aqua.jl/issues/77#issuecomment-1166304846
-        Aqua.test_all(AWSCRT, ambiguities = false)
-        Aqua.test_ambiguities(AWSCRT)
+    if !parallel
+        doctest(AWSCRT)
+        @testset "Aqua" begin
+            # TODO: see how this issue resolves and update https://github.com/JuliaTesting/Aqua.jl/issues/77#issuecomment-1166304846
+            Aqua.test_all(AWSCRT, ambiguities = false)
+            Aqua.test_ambiguities(AWSCRT)
+        end
     end
     @testset "mqtt_test.jl" begin
         @info "Starting mqtt_test.jl"

--- a/test/shadow_client_test.jl
+++ b/test/shadow_client_test.jl
@@ -1,100 +1,104 @@
 @testset "unnamed shadow document" begin
-    connection = new_mqtt_connection()
-    shadow = ShadowClient(connection, thing1_name, nothing)
-
-    msgs = []
-    function shadow_callback(
-        shadow_client::ShadowClient,
-        topic::String,
-        payload::String,
-        dup::Bool,
-        qos::aws_mqtt_qos,
-        retain::Bool,
-    )
-        push!(msgs, (; shadow_client, topic, payload, dup, qos, retain))
+    if parallel
+        return
     end
-
+    lock_test_unnamed_shadow(THING1_NAME) # only one test can use the unnamed shadow at a time
     try
-        tasks_and_ids = subscribe(shadow, AWS_MQTT_QOS_AT_LEAST_ONCE, shadow_callback)
-        for (task, id) in tasks_and_ids
-            fetch(task)
+        connection = new_mqtt_connection()
+        shadow = ShadowClient(connection, THING1_NAME, nothing)
+
+        msgs = []
+        function shadow_callback(
+            shadow_client::ShadowClient,
+            topic::String,
+            payload::String,
+            dup::Bool,
+            qos::aws_mqtt_qos,
+            retain::Bool,
+        )
+            push!(msgs, (; shadow_client, topic, payload, dup, qos, retain))
         end
 
-        fetch(publish(shadow, "/get", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
-        wait_for(() -> !isempty(msgs))
-        @test msgs[1][:shadow_client] === shadow
-        @test msgs[1][:topic] == "\$aws/things/$thing1_name/shadow/get/rejected"
-        @test msgs[1][:payload] == "{\"code\":404,\"message\":\"No shadow exists with name: '$thing1_name'\"}"
-        empty!(msgs)
+        try
+            fetch(subscribe(shadow, AWS_MQTT_QOS_AT_LEAST_ONCE, shadow_callback)[1])
+            fetch(publish(shadow, "/get", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
+            wait_for(() -> !isempty(msgs))
+            @test msgs[1][:shadow_client] === shadow
+            @test msgs[1][:topic] == "\$aws/things/$THING1_NAME/shadow/get/rejected"
+            @test msgs[1][:payload] == "{\"code\":404,\"message\":\"No shadow exists with name: '$THING1_NAME'\"}"
+            empty!(msgs)
 
-        fetch(
-            publish(
-                shadow,
-                "/update",
-                json(Dict("state" => Dict("reported" => Dict("foo" => 1)))),
-                AWS_MQTT_QOS_AT_LEAST_ONCE,
-            )[1],
-        )
-        wait_for(() -> length(msgs) >= 2)
-        @test findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/accepted", msgs) !== nothing
-        @test findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/documents", msgs) !== nothing
-        empty!(msgs)
+            fetch(
+                publish(
+                    shadow,
+                    "/update",
+                    json(Dict("state" => Dict("reported" => Dict("foo" => 1)))),
+                    AWS_MQTT_QOS_AT_LEAST_ONCE,
+                )[1],
+            )
+            wait_for(() -> length(msgs) >= 2)
+            @test findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/accepted", msgs) !== nothing
+            @test findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/documents", msgs) !== nothing
+            empty!(msgs)
 
-        fetch(
-            publish(
-                shadow,
-                "/update",
-                json(Dict("state" => Dict("desired" => Dict("foo" => 2)))),
-                AWS_MQTT_QOS_AT_LEAST_ONCE,
-            )[1],
-        )
-        wait_for(() -> length(msgs) >= 3)
-        @test findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/accepted", msgs) !== nothing
-        @test findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/documents", msgs) !== nothing
-        let msg = msgs[findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/delta", msgs)]
-            payload = JSON.parse(msg[:payload])
-            @test payload["state"]["foo"] == 2
+            fetch(
+                publish(
+                    shadow,
+                    "/update",
+                    json(Dict("state" => Dict("desired" => Dict("foo" => 2)))),
+                    AWS_MQTT_QOS_AT_LEAST_ONCE,
+                )[1],
+            )
+            wait_for(() -> length(msgs) >= 3)
+            @test findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/accepted", msgs) !== nothing
+            @test findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/documents", msgs) !== nothing
+            let msg = msgs[findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/delta", msgs)]
+                payload = JSON.parse(msg[:payload])
+                @test payload["state"]["foo"] == 2
+            end
+            empty!(msgs)
+
+            fetch(
+                publish(
+                    shadow,
+                    "/update",
+                    json(Dict("state" => Dict("reported" => Dict("foo" => 2)))),
+                    AWS_MQTT_QOS_AT_LEAST_ONCE,
+                )[1],
+            )
+            wait_for(() -> length(msgs) >= 2)
+            @test findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/accepted", msgs) !== nothing
+            @test findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/documents", msgs) !== nothing
+            @test findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/delta", msgs) === nothing
+            empty!(msgs)
+
+            fetch(
+                publish(
+                    shadow,
+                    "/update",
+                    json(Dict("state" => Dict("desired" => Dict("foo" => nothing)))),
+                    AWS_MQTT_QOS_AT_LEAST_ONCE,
+                )[1],
+            )
+            wait_for(() -> length(msgs) >= 2)
+            @test findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/accepted", msgs) !== nothing
+            let msg = msgs[findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/update/documents", msgs)]
+                payload = JSON.parse(msg[:payload])
+                @test !haskey(payload["current"]["state"], "desired")
+                @test haskey(payload["current"]["state"], "reported")
+            end
+            empty!(msgs)
+
+            fetch(publish(shadow, "/delete", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
+            wait_for(() -> length(msgs) >= 1)
+            @test findfirst(it -> it[:topic] == "\$aws/things/$THING1_NAME/shadow/delete/accepted", msgs) !== nothing
+            empty!(msgs)
+
+            fetch(unsubscribe(shadow)[1])
+        finally
+            fetch(publish(shadow, "/delete", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
         end
-        empty!(msgs)
-
-        fetch(
-            publish(
-                shadow,
-                "/update",
-                json(Dict("state" => Dict("reported" => Dict("foo" => 2)))),
-                AWS_MQTT_QOS_AT_LEAST_ONCE,
-            )[1],
-        )
-        wait_for(() -> length(msgs) >= 2)
-        @test findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/accepted", msgs) !== nothing
-        @test findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/documents", msgs) !== nothing
-        @test findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/delta", msgs) === nothing
-        empty!(msgs)
-
-        fetch(
-            publish(
-                shadow,
-                "/update",
-                json(Dict("state" => Dict("desired" => Dict("foo" => nothing)))),
-                AWS_MQTT_QOS_AT_LEAST_ONCE,
-            )[1],
-        )
-        wait_for(() -> length(msgs) >= 2)
-        @test findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/accepted", msgs) !== nothing
-        let msg = msgs[findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/update/documents", msgs)]
-            payload = JSON.parse(msg[:payload])
-            @test !haskey(payload["current"]["state"], "desired")
-            @test haskey(payload["current"]["state"], "reported")
-        end
-        empty!(msgs)
-
-        fetch(publish(shadow, "/delete", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
-        wait_for(() -> length(msgs) >= 1)
-        @test findfirst(it -> it[:topic] == "\$aws/things/$thing1_name/shadow/delete/accepted", msgs) !== nothing
-        empty!(msgs)
-
-        fetch(unsubscribe(shadow)[1])
     finally
-        fetch(publish(shadow, "/delete", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
+        unlock_test_unnamed_shadow(THING1_NAME)
     end
 end

--- a/test/shadow_framework_integ_test.jl
+++ b/test/shadow_framework_integ_test.jl
@@ -3,7 +3,7 @@ struct OOBShadowClient
     msgs::Vector{Any}
     shadow_callback::Function
 
-    function OOBShadowClient(oob_connection, thing1_name, shadow_name)
+    function OOBShadowClient(oob_connection, THING1_NAME, shadow_name)
         msgs = Any[]
         function shadow_callback(
             shadow_client::ShadowClient,
@@ -15,15 +15,12 @@ struct OOBShadowClient
         )
             push!(msgs, (; shadow_client, topic, payload, dup, qos, retain))
         end
-        return new(ShadowClient(oob_connection, thing1_name, shadow_name), msgs, shadow_callback)
+        return new(ShadowClient(oob_connection, THING1_NAME, shadow_name), msgs, shadow_callback)
     end
 end
 
 function subscribe_for_single_shadow_msg(oobsc, topic, payload)
-    tasks_and_ids = subscribe(oobsc.shadow_client, AWS_MQTT_QOS_AT_LEAST_ONCE, oobsc.shadow_callback)
-    for (task, id) in tasks_and_ids
-        fetch(task)
-    end
+    fetch(subscribe(oobsc.shadow_client, AWS_MQTT_QOS_AT_LEAST_ONCE, oobsc.shadow_callback)[1])
     fetch(publish(oobsc.shadow_client, topic, payload, AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
     wait_for(() -> !isempty(oobsc.msgs))
     fetch(unsubscribe(oobsc.shadow_client)[1])
@@ -77,7 +74,7 @@ end
 
     sf = ShadowFramework(
         connection,
-        thing1_name,
+        THING1_NAME,
         shadow_name,
         doc;
         shadow_document_pre_update_callback = pre_update_cb,
@@ -99,7 +96,7 @@ end
     end
 
     oobc = new_mqtt_connection()
-    oobsc = OOBShadowClient(oobc, thing1_name, shadow_name)
+    oobsc = OOBShadowClient(oobc, THING1_NAME, shadow_name)
 
     try
         fetch(subscribe(sf)[1])
@@ -117,9 +114,7 @@ end
         @test doc["foo"] == 2
 
         @info "unsubscribing"
-        for (task, id) in unsubscribe(sf)
-            fetch(task)
-        end
+        fetch(unsubscribe(sf)[1])
         @info "done unsubscribing"
 
         @info "publishing second update"
@@ -135,121 +130,143 @@ end
         @test doc["foo"] == 2 # check the update did not happen
 
         fetch(unsubscribe(oobsc.shadow_client)[1])
+    catch ex
+        @error exception = (ex, catch_backtrace())
     finally
         fetch(publish(sc, "/delete", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
     end
 end
 
-@testset "the initial update syncs with the desired state ($shadow_type)" for shadow_type in [:unnamed, :named]
-    connection = new_mqtt_connection()
-    shadow_name = if shadow_type == :unnamed
-        nothing
-    else
-        random_shadow_name()
+shadow_types = parallel ? [:named] : [:named, :unnamed]
+@testset "the initial update syncs with the desired state ($shadow_type)" for shadow_type in shadow_types
+    if shadow_type == :unnamed
+        lock_test_unnamed_shadow(THING1_NAME) # only one test can use the unnamed shadow at a time
     end
-    doc = Dict("foo" => 1)
-
-    values_foo = []
-    foo_cb = x -> push!(values_foo, x)
-
-    values_pre_update = []
-    pre_update_cb = x -> push!(values_pre_update, x)
-
-    values_post_update = []
-    latch_post_update = Ref(CountDownLatch(1))
-    post_update_cb = x -> begin
-        push!(values_post_update, x)
-        count_down(latch_post_update[])
-    end
-
-    sf = ShadowFramework(
-        connection,
-        thing1_name,
-        shadow_name,
-        doc;
-        shadow_document_pre_update_callback = pre_update_cb,
-        shadow_document_post_update_callback = post_update_cb,
-        shadow_document_property_callbacks = Dict{String,Function}("foo" => foo_cb),
-    )
-    sc = shadow_client(sf)
-
-    msgs = []
-    function shadow_callback(
-        shadow_client::ShadowClient,
-        topic::String,
-        payload::String,
-        dup::Bool,
-        qos::aws_mqtt_qos,
-        retain::Bool,
-    )
-        push!(msgs, (; shadow_client, topic, payload, dup, qos, retain))
-    end
-
-    oobc = new_mqtt_connection()
-    oobsc = OOBShadowClient(oobc, thing1_name, shadow_name)
-
     try
-        fetch(subscribe(sf)[1]) # subscribe and trigger the initial update, which will fail because there is no shadow
-        sleep(1) # we need to make sure the local shadow won't get modified. no better way than to just wait a bit in case something modifies it.
-        @test collect(keys(doc)) == ["version", "foo"] # we should have the version and the initial foo key we set
-        @test doc["foo"] == 1 # should be unchanged from our initial state
-
-        @info "unsubscribing"
-        for (task, id) in unsubscribe(sf)
-            fetch(task)
+        connection = new_mqtt_connection()
+        shadow_name = if shadow_type == :unnamed
+            nothing
+        else
+            random_shadow_name()
         end
-        @info "done unsubscribing"
+        doc = Dict("foo" => 1)
 
-        # the intitial shadow doc state should have been published as reported state from the initial subscribe
-        subscribe_for_single_shadow_msg(oobsc, "/get", "")
-        test_get_accepted_payload_equals_shadow_doc(oobsc.msgs[1][:payload], doc)
+        values_foo = []
+        foo_cb = x -> push!(values_foo, x)
 
-        # do this subscribe after subscribe_for_single_shadow_msg since that unsubscribes
-        update_msgs = []
-        task, id = subscribe(
-            oobsc.shadow_client,
-            "/update",
-            AWS_MQTT_QOS_AT_LEAST_ONCE,
-            (topic::String, payload::String, dup::Bool, qos::aws_mqtt_qos, retain::Bool) ->
-                push!(update_msgs, (; topic, payload, dup, qos, retain)),
+        values_pre_update = []
+        pre_update_cb = x -> push!(values_pre_update, x)
+
+        values_post_update = []
+        latch_post_update = Ref(CountDownLatch(1))
+        post_update_cb = x -> begin
+            push!(values_post_update, x)
+            count_down(latch_post_update[])
+        end
+
+        sf = ShadowFramework(
+            connection,
+            THING1_NAME,
+            shadow_name,
+            doc;
+            shadow_document_pre_update_callback = pre_update_cb,
+            shadow_document_post_update_callback = post_update_cb,
+            shadow_document_property_callbacks = Dict{String,Function}("foo" => foo_cb),
         )
-        fetch(task)
+        sc = shadow_client(sf)
 
-        # Prepare some content so we can test the initial update
-        @info "publishing out of band /update"
-        fetch(
-            publish(
+        msgs = []
+        function shadow_callback(
+            shadow_client::ShadowClient,
+            topic::String,
+            payload::String,
+            dup::Bool,
+            qos::aws_mqtt_qos,
+            retain::Bool,
+        )
+            push!(msgs, (; shadow_client, topic, payload, dup, qos, retain))
+        end
+
+        oobc = new_mqtt_connection()
+        oobsc = OOBShadowClient(oobc, THING1_NAME, shadow_name)
+
+        try
+            fetch(publish(sc, "/delete", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1]) # ensure the shadow is deleted just in case of a prior broken test
+
+            fetch(subscribe(sf)[1]) # subscribe and trigger the initial update, which will fail because there is no shadow
+            wait_until_synced(sf)
+            sleep(3) # we need to make sure the local shadow won't get modified. no better way than to just wait a bit in case something modifies it.
+            @test collect(keys(doc)) == ["version", "foo"] # we should have the version and the initial foo key we set
+            @test doc["foo"] == 1 # should be unchanged from our initial state
+
+            @info "unsubscribing"
+            fetch(unsubscribe(sf)[1])
+            @info "done unsubscribing"
+
+            # the intitial shadow doc state should have been published as reported state from the initial subscribe.
+            # test this is correct on the broker's side.
+            @info "testing shadow state on the broker"
+            subscribe_for_single_shadow_msg(oobsc, "/get", "")
+            test_get_accepted_payload_equals_shadow_doc(oobsc.msgs[1][:payload], doc)
+
+            @info "subscribing for out of band shadow updates"
+            update_msgs = []
+            task, id = subscribe(
                 oobsc.shadow_client,
                 "/update",
-                json(Dict("state" => Dict("desired" => Dict("foo" => 2)))),
                 AWS_MQTT_QOS_AT_LEAST_ONCE,
-            )[1],
-        )
-        sleep(3) # pretend the shadow moved while we were offline
-        @info "subscribing in band shadow"
-        values_post_update = []
-        fetch(subscribe(sf)[1]) # subscribe and trigger the initial update
-        wait_for(() -> length(values_post_update) >= 1) # wait for the update to finish since it requires multiple messages
-        # The initial update should have pulled in that desired state
-        @test doc["foo"] == 2
-        @test values_foo == [2]
-        @test values_pre_update == [Dict("foo" => 2)]
-        @test values_post_update == [doc]
-        wait_for(() -> length(update_msgs) >= 2)
-        @test length(update_msgs) == 2
-        @show update_msgs
-        payloads = [JSON.parse(it.payload) for it in update_msgs]
-        @test any(it -> maybe_get(it, "state", "desired", "foo") == 2, payloads) # from our desired state update above
-        @test any(it -> maybe_get(it, "state", "reported", "foo") == 2, payloads) # new reported state after the initial get
-
-        @info "unsubscribing"
-        for (task, id) in unsubscribe(sf)
+                (topic::String, payload::String, dup::Bool, qos::aws_mqtt_qos, retain::Bool) -> begin
+                    @info "received OOB shadow update" topic payload
+                    push!(update_msgs, (; topic, payload, dup, qos, retain))
+                end,
+            )
+            @info "waiting for out of band shadow update subscribe to finish" id
             fetch(task)
+
+            # Prepare some content so we can test the initial update. i.e. pretend the shadow moved while we were offline
+            @info "publishing out of band /update"
+            fetch(
+                publish(
+                    oobsc.shadow_client,
+                    "/update",
+                    json(Dict("state" => Dict("desired" => Dict("foo" => 2)))),
+                    AWS_MQTT_QOS_AT_LEAST_ONCE,
+                )[1],
+            )
+
+            # wait a bit so that the sf doesn't get any responses from the /update above. we're trying to test what
+            # happens on the initial sync, not what happens after that, so the sf should not be getting any messages
+            # other than the ones published in response to its initial /get
+            sleep(3)
+
+            @info "subscribing in band shadow"
+            values_post_update = []
+            fetch(subscribe(sf)[1]) # subscribe and trigger the initial update
+            wait_until_synced(sf)
+            wait_for(() -> length(values_post_update) >= 1) # wait for the update to finish since it requires multiple messages
+            # The initial update should have pulled in that desired state
+            @test doc["foo"] == 2
+            @test values_foo == [2]
+            @test values_pre_update == [Dict("foo" => 2)]
+            @test values_post_update == [doc]
+            wait_for(() -> length(update_msgs) >= 2; throw = false)
+            @test length(update_msgs) == 2
+            @show update_msgs
+            payloads = [JSON.parse(it.payload) for it in update_msgs]
+            @test any(it -> maybe_get(it, "state", "desired", "foo") == 2, payloads) # from our desired state update above
+            @test any(it -> maybe_get(it, "state", "reported", "foo") == 2, payloads) # new reported state after the initial get
+
+            @info "unsubscribing"
+            fetch(unsubscribe(sf)[1])
+            @info "done unsubscribing"
+            fetch(unsubscribe(oobsc.shadow_client)[1])
+        finally
+            fetch(publish(sc, "/delete", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
         end
-        @info "done unsubscribing"
-        fetch(unsubscribe(oobsc.shadow_client)[1])
     finally
-        fetch(publish(sc, "/delete", "", AWS_MQTT_QOS_AT_LEAST_ONCE)[1])
+        if shadow_type == :unnamed
+            unlock_test_unnamed_shadow(THING1_NAME)
+        end
     end
 end
 
@@ -273,7 +290,7 @@ end
 
     sf = ShadowFramework(
         connection,
-        thing1_name,
+        THING1_NAME,
         shadow_name,
         doc;
         shadow_document_pre_update_callback = pre_update_cb,
@@ -295,7 +312,7 @@ end
     end
 
     oobc = new_mqtt_connection()
-    oobsc = OOBShadowClient(oobc, thing1_name, shadow_name)
+    oobsc = OOBShadowClient(oobc, THING1_NAME, shadow_name)
 
     update_msgs = []
     task, id = subscribe(
@@ -343,9 +360,7 @@ end
         @test isempty(update_msgs)
 
         @info "unsubscribing"
-        for (task, id) in unsubscribe(sf)
-            fetch(task)
-        end
+        fetch(unsubscribe(sf)[1])
         @info "done unsubscribing"
         fetch(unsubscribe(oobsc.shadow_client)[1])
     finally
@@ -374,7 +389,7 @@ end
 
         sf = ShadowFramework(
             connection,
-            thing1_name,
+            THING1_NAME,
             shadow_name,
             doc;
             shadow_document_pre_update_callback = pre_update_cb,
@@ -396,7 +411,7 @@ end
         end
 
         oobc = new_mqtt_connection()
-        oobsc = OOBShadowClient(oobc, thing1_name, shadow_name)
+        oobsc = OOBShadowClient(oobc, THING1_NAME, shadow_name)
 
         update_msgs = []
         task, id = subscribe(
@@ -411,6 +426,9 @@ end
         try
             @info "subscribing"
             fetch(subscribe(sf)[1])
+            # wait for the first publish to finish, otherwise we will race it with our next update, which could arrive
+            # first and break this test
+            wait_until_synced(sf)
 
             # publish a /update. this should be accepted. the local shadow should be updated.
             # an /update should be published with the new reported state.
@@ -428,13 +446,12 @@ end
             wait_for(() -> length(update_msgs) >= 3)
             @test length(update_msgs) == 3
             payloads = [JSON.parse(it.payload) for it in update_msgs]
+            # FIXME: this test can be flaky
             @test any(it -> maybe_get(it, "state", "reported", "foo") == 1, payloads) # from the initial update since the shadow doc didn't exist
             @test any(it -> maybe_get(it, "state", "reported", "foo") == 2, payloads) # from our desired state update above
 
             @info "unsubscribing"
-            for (task, id) in unsubscribe(sf)
-                fetch(task)
-            end
+            fetch(unsubscribe(sf)[1])
             @info "done unsubscribing"
             fetch(unsubscribe(oobsc.shadow_client)[1])
         finally
@@ -463,7 +480,7 @@ end
 
         sf = ShadowFramework(
             connection,
-            thing1_name,
+            THING1_NAME,
             shadow_name,
             doc;
             shadow_document_pre_update_callback = pre_update_cb,
@@ -485,7 +502,7 @@ end
         end
 
         oobc = new_mqtt_connection()
-        oobsc = OOBShadowClient(oobc, thing1_name, shadow_name)
+        oobsc = OOBShadowClient(oobc, THING1_NAME, shadow_name)
 
         update_msgs = []
         task, id = subscribe(
@@ -500,6 +517,9 @@ end
         try
             @info "subscribing"
             fetch(subscribe(sf)[1])
+            # wait for the first publish to finish, otherwise we will race it with our next update, which could arrive
+            # first and break this test
+            wait_until_synced(sf)
 
             # publish an /update which adds bar=1. this should be rejected because bar is not present in the struct.
             # the local shadow should not be updated. an /update should not be published.
@@ -547,9 +567,7 @@ end
             # there should not be any other update because the bar update should not have been accepted
 
             @info "unsubscribing"
-            for (task, id) in unsubscribe(sf)
-                fetch(task)
-            end
+            fetch(unsubscribe(sf)[1])
             @info "done unsubscribing"
             fetch(unsubscribe(oobsc.shadow_client)[1])
         finally

--- a/test/shadow_framework_test.jl
+++ b/test/shadow_framework_test.jl
@@ -179,6 +179,23 @@ end
     @test @test_logs (:error,) match_mode = :any !AWSCRT._do_local_shadow_update!(sf, state) # no update the second time
 end
 
+@testset "_update_local_shadow_from_get!" for doc in ALL_EXAMPLE_SD_1
+    doc_copy = deepcopy(doc)
+    sf = empty_shadow_framework(doc_copy)
+    @test AWSCRT._update_local_shadow_from_get!(
+        sf,
+        json(Dict("state" => Dict("delta" => Dict("foo" => 2)), "version" => 3)),
+    )
+    @test are_shadow_states_equal_without_version(doc_copy, Dict("foo" => 2, "bar" => "a"))
+end
+
+@testset "_update_local_shadow_from_delta!" for doc in ALL_EXAMPLE_SD_1
+    doc_copy = deepcopy(doc)
+    sf = empty_shadow_framework(doc_copy)
+    @test AWSCRT._update_local_shadow_from_delta!(sf, json(Dict("state" => Dict("foo" => 2), "version" => 3)))
+    @test are_shadow_states_equal_without_version(doc_copy, Dict("foo" => 2, "bar" => "a"))
+end
+
 @testset "out of order messages, version is respected" for doc in ALL_EXAMPLE_SD_1,
     update_type in [:get_accepted, :delta]
 

--- a/test/testheader.jl
+++ b/test/testheader.jl
@@ -1,0 +1,19 @@
+parallel = false
+if get(ENV, "AWSCRT_TESTS_PARALLEL", "false") == "true"
+    @info "Configuring tests to run in parallel. Note not all tests will be ran."
+    parallel = true
+end
+
+if !parallel
+    rm(joinpath(@__DIR__, "log.txt"); force = true)
+    ENV["AWS_CRT_MEMORY_TRACING"] = "1"
+    ENV["AWS_CRT_LOG_LEVEL"] = "6"
+    ENV["AWS_CRT_LOG_PATH"] = joinpath(@__DIR__, "log.txt")
+end
+
+ENV["JULIA_DEBUG"] = "AWSCRT"
+
+using Test, AWSCRT, LibAWSCRT, JSON, CountDownLatches, Random, Documenter, Aqua, Dates, AWS
+@service DynamoDB
+
+include("util.jl")

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,6 +1,6 @@
 import Base: ==, isequal
 
-const thing1_name = "AWSCRT_Test1"
+const THING1_NAME = "AWSCRT_Test1"
 
 abstract type Comparable end
 
@@ -11,12 +11,12 @@ function isequal(a::T, b::T) where {T<:Comparable}
     isequal(getfield.(Ref(a), f), getfield.(Ref(b), f))
 end
 
-function wait_for(predicate, timeout = Timer(5))
+function wait_for(predicate, timeout = Timer(5); throw = true)
     while !predicate() && isopen(timeout)
         sleep(0.1)
     end
 
-    if !isopen(timeout)
+    if !isopen(timeout) && throw
         error("wait_for timeout")
     end
 end
@@ -24,11 +24,21 @@ end
 sort_pairs(it) = sort(it; by = x -> x[begin])
 
 function new_tls_ctx()
-    tls_ctx_options = create_client_with_mtls(
-        ENV["CERT_STRING"],
-        ENV["PRI_KEY_STRING"],
-        ca_filepath = joinpath(@__DIR__, "certs", "AmazonRootCA1.pem"),
-    )
+    tls_ctx_options = if haskey(ENV, "CERT_STRING")
+        create_client_with_mtls(
+            ENV["CERT_STRING"],
+            ENV["PRI_KEY_STRING"],
+            ca_filepath = joinpath(@__DIR__, "certs", "AmazonRootCA1.pem"),
+        )
+    elseif haskey(ENV, "CERT_PATH")
+        create_client_with_mtls_from_path(
+            ENV["CERT_PATH"],
+            ENV["PRI_KEY_PATH"],
+            ca_filepath = joinpath(@__DIR__, "certs", "AmazonRootCA1.pem"),
+        )
+    else
+        error("could not find cert in ENV")
+    end
     return ClientTLSContext(tls_ctx_options)
 end
 
@@ -47,4 +57,31 @@ Generates a test-independently-random client ID. Reusing the same client ID in m
 """
 random_client_id() = randstring(MersenneTwister(), 48)
 
-random_shadow_name() = "shadow-$(randstring(MersenneTwister(), 6))"
+random_shadow_name() = "shadow-$(randstring(MersenneTwister(), 10))"
+
+const LOCK_TABLE_NAME = "awscrt-test-locks"
+
+function lock_test(lock_name)
+    f = retry(delays = ExponentialBackOff(n = 5, first_delay = 5, max_delay = 60)) do
+        try
+            DynamoDB.put_item(
+                Dict("lock_name" => Dict("S" => lock_name)),
+                LOCK_TABLE_NAME,
+                Dict("ConditionExpression" => "attribute_not_exists(lock_name)"),
+            )
+            return nothing
+        catch ex
+            @warn "Failed to lock test $lock_name because of" exception = (ex, catch_backtrace())
+            rethrow()
+        end
+    end
+    return f()
+end
+
+function unlock_test(lock_name)
+    DynamoDB.delete_item(Dict("lock_name" => Dict("S" => lock_name)), LOCK_TABLE_NAME)
+    return nothing
+end
+
+lock_test_unnamed_shadow(thing) = lock_test("$thing-unnamed_shadow")
+unlock_test_unnamed_shadow(thing) = unlock_test("$thing-unnamed_shadow")


### PR DESCRIPTION
Breaking changes:
1. The `subscribe` and `unsubscribe` methods for `ShadowClient` return a single task and list of ids instead of a list of task, id pairs to be less confusing.
2. Callbacks used to run sequentially, now they run concurrently.
3. macOS support dropped due to crashes.
4. AWSCRT downgraded to 0.1.2. This will be updated in the future.

New features:
1. Added `wait_until_synced`.

Bugfixes:
1. Fixed a handful of concurrency bugs in `ShadowFramework`.
2. Fixed a crash due to ForeignCallbacks.jl.
3. Fixed a handful of potential memory corruption bugs due to native code interactions.

Other notes:
Removed ForeignCallbacks.jl now that the foreign threads work is merged into base Julia.
