### PR TITLE
Add Julia allocator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSCRT"
 uuid = "df31ea59-17a4-4ebd-9d69-4f45266dc2c7"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 CountDownLatches = "621fb831-fdad-4fff-93ac-1af7b7ed19e3"

--- a/src/AWSCRT.jl
+++ b/src/AWSCRT.jl
@@ -162,7 +162,7 @@ function __init__()
             end
             frames_per_stack = parse(Int, strip(get(ENV, "AWS_CRT_MEMORY_TRACING_FRAMES_PER_STACK", "0")))
             aws_mem_tracer_new(aws_default_allocator(), C_NULL, level, frames_per_stack)
-        elseif Base.get_bool_env("AWS_CRT_USE_JL_ALLOCATOR", false)
+        elseif get(ENV, "AWS_CRT_USE_JL_ALLOCATOR", "") == "true"
             new_jl_allocator()
         else
             aws_default_allocator()

--- a/src/AWSCRT.jl
+++ b/src/AWSCRT.jl
@@ -35,6 +35,10 @@ const _C_ON_SUBSCRIBE_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
 const _C_ON_UNSUBSCRIBE_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
 const _C_ON_RESUBSCRIBE_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
 const _C_ON_PUBLISH_COMPLETE = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_AWS_MALLOC = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_AWS_FREE = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_AWS_REALLOC = Ref{Ptr{Cvoid}}(C_NULL)
+const _C_AWS_CALLOC = Ref{Ptr{Cvoid}}(C_NULL)
 
 function _release(; include_mem_tracer = isempty(get(ENV, "AWS_CRT_MEMORY_TRACING", "")))
     aws_thread_set_managed_join_timeout_ns(5e8) # 0.5 seconds
@@ -60,6 +64,8 @@ const advanced_use_note =
     "Note on advanced use: the internal constructor on this struct has been left at its " *
     "default so that you can bring your own native data if you need to. However, you are then responsible for the " *
     "memory management of that data."
+
+include("allocator.jl")
 
 include("AWSIO.jl")
 export EventLoopGroup
@@ -139,6 +145,10 @@ function __init__()
     )
     _C_ON_PUBLISH_COMPLETE[] =
         @cfunction(_c_on_publish_complete, Cvoid, (Ptr{aws_mqtt_client_connection}, Cuint, Cint, Ptr{Cvoid}))
+    _C_AWS_MALLOC[] = @cfunction(_c_aws_malloc, Ptr{Cvoid}, (Ptr{aws_allocator}, Csize_t))
+    _C_AWS_FREE[] = @cfunction(_c_aws_free, Cvoid, (Ptr{aws_allocator}, Ptr{Cvoid}))
+    _C_AWS_REALLOC[] = @cfunction(_c_aws_realloc, Ptr{Cvoid}, (Ptr{aws_allocator}, Ptr{Cvoid}, Csize_t, Csize_t))
+    _C_AWS_CALLOC[] = @cfunction(_c_aws_calloc, Ptr{Cvoid}, (Ptr{aws_allocator}, Csize_t, Csize_t))
 
     _AWSCRT_ALLOCATOR[] = let level = get(ENV, "AWS_CRT_MEMORY_TRACING", "")
         if !isempty(level)
@@ -152,6 +162,8 @@ function __init__()
             end
             frames_per_stack = parse(Int, strip(get(ENV, "AWS_CRT_MEMORY_TRACING_FRAMES_PER_STACK", "0")))
             aws_mem_tracer_new(aws_default_allocator(), C_NULL, level, frames_per_stack)
+        elseif Base.get_bool_env("AWS_CRT_USE_JL_ALLOCATOR", false)
+            new_jl_allocator()
         else
             aws_default_allocator()
         end

--- a/src/allocator.jl
+++ b/src/allocator.jl
@@ -1,0 +1,29 @@
+function _c_aws_malloc(allocator::Ptr{aws_allocator}, size::Csize_t)::Ptr{Cvoid}
+    return @ccall jl_malloc(size::Csize_t)::Ptr{Cvoid}
+end
+
+function _c_aws_free(allocator::Ptr{aws_allocator}, ptr::Ptr{Cvoid})::Cvoid
+    return @ccall jl_free(ptr::Ptr{Cvoid})::Cvoid
+end
+
+function _c_aws_realloc(
+    allocator::Ptr{aws_allocator},
+    ptr::Ptr{Cvoid},
+    old_size::Csize_t,
+    new_size::Csize_t,
+)::Ptr{Cvoid}
+    return @ccall jl_realloc(ptr::Ptr{Cvoid}, new_size::Csize_t)::Ptr{Cvoid}
+end
+
+function _c_aws_calloc(allocator::Ptr{aws_allocator}, num::Csize_t, size::Csize_t)::Ptr{Cvoid}
+    return @ccall jl_calloc(num::Csize_t, size::Csize_t)::Ptr{Cvoid}
+end
+
+"""
+    new_jl_allocator()
+
+Returns an [`aws_allocator`](@ref) which integrates with Julia's GC to track memory allocated by native code.
+"""
+function new_jl_allocator()
+    return aws_allocator(_C_AWS_MALLOC[], _C_AWS_FREE[], _C_AWS_REALLOC[], _C_AWS_CALLOC[], C_NULL)
+end

--- a/src/allocator.jl
+++ b/src/allocator.jl
@@ -22,7 +22,7 @@ end
 """
     new_jl_allocator()
 
-Returns an [`aws_allocator`](@ref) which integrates with Julia's GC to track memory allocated by native code.
+Returns an `aws_allocator` which integrates with Julia's GC to track memory allocated by native code.
 """
 function new_jl_allocator()
     return aws_allocator(_C_AWS_MALLOC[], _C_AWS_FREE[], _C_AWS_REALLOC[], _C_AWS_CALLOC[], C_NULL)


### PR DESCRIPTION
Adds an allocator which integrates with Julia's GC behind a new env var `AWS_CRT_USE_JL_ALLOCATOR`.
