### PR TITLE
Ignore old version numbers in the reported or delta state when updating the local shadow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSCRT"
 uuid = "df31ea59-17a4-4ebd-9d69-4f45266dc2c7"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 CountDownLatches = "621fb831-fdad-4fff-93ac-1af7b7ed19e3"

--- a/src/ShadowFramework.jl
+++ b/src/ShadowFramework.jl
@@ -353,6 +353,7 @@ function _update_local_shadow_from_get!(sf::ShadowFramework, payload_str::String
                     if delta !== nothing
                         _recursive_merge!(reported, delta)
                     end
+                    delete!(reported, "version") # ignore the old reported version because we get a new one from the broker
                     return _do_local_shadow_update!(sf, reported)
                 else
                     if delta !== nothing
@@ -393,6 +394,7 @@ function _update_local_shadow_from_delta!(sf::ShadowFramework, payload_str::Stri
         if _version_allows_update(sf._shadow_document, version)
             _set_version!(sf._shadow_document, version)
             state = get(payload, "state", nothing)
+            delete!(state, "version") # ignore the old reported version because we get a new one from the broker
             if state !== nothing
                 return _do_local_shadow_update!(sf, state)
             end

--- a/test/shadow_framework_test.jl
+++ b/test/shadow_framework_test.jl
@@ -211,12 +211,28 @@ end
     @test are_shadow_states_equal_without_version(doc_copy, Dict("foo" => 2, "bar" => "a"))
 end
 
+@testset "_update_local_shadow_from_get! ignores an old version in the reported state" begin
+    doc = EXAMPLE_SD_1_DICT
+    doc_copy = deepcopy(doc)
+    sf = empty_shadow_framework(doc_copy)
+    @test AWSCRT._update_local_shadow_from_get!(
+        sf,
+        json(Dict("state" => Dict("delta" => Dict("foo" => 2), "reported" => Dict("version" => 1)), "version" => 3)),
+    )
+    @test are_shadow_states_equal_without_version(doc_copy, Dict("foo" => 2, "bar" => "a"))
+    @test doc_copy["version"] == 3
+end
+
 @testset "_update_local_shadow_from_delta!" begin
     doc = EXAMPLE_SD_1_DICT
     doc_copy = deepcopy(doc)
     sf = empty_shadow_framework(doc_copy)
-    @test AWSCRT._update_local_shadow_from_delta!(sf, json(Dict("state" => Dict("foo" => 2), "version" => 3)))
+    @test AWSCRT._update_local_shadow_from_delta!(
+        sf,
+        json(Dict("state" => Dict("foo" => 2, "version" => 1), "version" => 3)),
+    )
     @test are_shadow_states_equal_without_version(doc_copy, Dict("foo" => 2, "bar" => "a"))
+    @test doc_copy["version"] == 3
 end
 
 @testset "out of order messages, version is respected" for update_type in [:get_accepted, :delta]

--- a/test/util.jl
+++ b/test/util.jl
@@ -42,8 +42,8 @@ function new_tls_ctx()
     return ClientTLSContext(tls_ctx_options)
 end
 
-function new_mqtt_connection()
-    client = MQTTClient(new_tls_ctx())
+function new_mqtt_connection(; tls = new_tls_ctx())
+    client = MQTTClient(tls)
     connection = MQTTConnection(client)
     client_id = random_client_id()
     @show client_id


### PR DESCRIPTION
#29 broke the initial shadow sync because after writing the new version we overwrote it with the old version from the
reported state. That old version should always be ignored when we have a new version from the broker.
